### PR TITLE
Optimize parenthesization

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,10 @@ Install requirements:
 ```bash
 pip install -r requirements.txt
 ```
+
+Run tests:
+
+
+```bash
+python -m unittest discover unit-tests/
+```

--- a/unit-tests/test_parenthesize.py
+++ b/unit-tests/test_parenthesize.py
@@ -1,0 +1,21 @@
+import unittest
+from auchann.chat_annotate import correct_parenthesize
+
+
+class TestParenthesize(unittest.TestCase):
+    def test_parenthesize(self):
+        data = [("n", "een", "(ee)n"),
+                ("wee", "twee", "(t)wee"),
+                ("gee", "geen", "gee(n)"),
+                ("ga-ga-gaan", "gaan", "\u21ABga-ga\u21ABgaan"),
+                ("es", "eens", "e(en)s"),
+                ("feliteerd", "gefeliciteerd", "(ge)feli(ci)teerd")]
+
+        for original, correction, expected in data:
+            actual = correct_parenthesize(original, correction)
+            self.assertEqual(actual, expected,
+                             f"{original} \u2192 {correction}")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hierdoor wordt `es → eens` geannoteerd als `e(en)s` i.p.v. `(e)e(n)s` ook wordt `feliteerd → gefelicteerd`, `(ge)feli(ci)teerd` i.p.v. `(ge)fel(ic)iteerd`.