### PR TITLE
Split replace penalty

### DIFF
--- a/auchann/align_words.py
+++ b/auchann/align_words.py
@@ -14,6 +14,17 @@ class TokenOperation(Enum):
 
 
 class TokenCorrection:
+    """Represents a way in which a (group of) token(s) can be represented 
+    in a CHAT annotation.
+
+    Params:
+        insert: token(s) to potentially replace a token or be inserted 
+                in the annotation (derived from correction string)
+        remove: token(s) to potentially be removed or replaced in the 
+                annotation (derived form the transcript string)
+        operation: INSERT, REPLACE, REMOVE, or COPY
+        is_filler/is_fragment: True if removed token is a filler or fragment    
+    """
     insert: List[Optional[str]]
     remove: List[Optional[str]]
     operation: TokenOperation
@@ -64,6 +75,7 @@ class TokenCorrection:
             return f'UNKNOWN OPERATION {self.operation}'
 
     def __str__remove(self):
+        """Adds special annotations for specific remove operations"""
         remove = ' '.join(self.remove)
         if self.is_filler:
             return f'&-{remove}'

--- a/auchann/align_words.py
+++ b/auchann/align_words.py
@@ -147,6 +147,7 @@ class AlignmentSettings:
 
     def __init__(self):
         self.lookahead = 2
+        self.split_penalty = False
         self.replacements = data.replacements
         self.fillers = data.fillers
         self.fragments = data.fragments
@@ -349,7 +350,7 @@ class AlignmentSession:
             self.align_insert(transcript_offset, correction_offset) + \
             self.align_remove(transcript_offset, correction_offset) + \
             self.align_split(transcript_offset, correction_offset,
-                             self.settings.split_lookaheads)
+                             self.settings.split_lookaheads, self.settings.split_penalty)
 
         alignments.sort(key=lambda alignment: alignment.distance)
 
@@ -405,7 +406,8 @@ class AlignmentSession:
     def align_split(self,
                     transcript_offset: int,
                     correction_offset: int,
-                    split_lookaheads: List[int]) -> List[TokenAlignments]:
+                    split_lookaheads: List[int],
+                    split_penalty: bool) -> List[TokenAlignments]:
         # OPTION 4: detect split of one word into two words e.g. was -> wat is
         corrections: List[TokenAlignments] = []
         for lookahead in split_lookaheads:
@@ -429,6 +431,8 @@ class AlignmentSession:
                     transcript_offset+1, correction_offset+lookahead)
                 distance = sum(len(token)
                                for token in correction_tokens) - len(transcript_token)
+                if split_penalty:
+                    distance += 0.1
 
                 corrections += prepend_correction(
                     correction,

--- a/auchann/align_words.py
+++ b/auchann/align_words.py
@@ -291,7 +291,7 @@ def align_split(transcript: str, corrections: List[str]) -> List[str]:
 
 
 def prepend_correction(correction: TokenCorrection,
-                       distance: int | float,
+                       distance: Union[int, float],
                        alignments: Iterable[TokenAlignments]) -> Iterable[TokenAlignments]:
     for alignment in alignments:
         yield TokenAlignments([correction] + alignment.corrections, distance + alignment.distance)

--- a/auchann/align_words.py
+++ b/auchann/align_words.py
@@ -291,7 +291,7 @@ def align_split(transcript: str, corrections: List[str]) -> List[str]:
 
 
 def prepend_correction(correction: TokenCorrection,
-                       distance: int,
+                       distance: int | float,
                        alignments: Iterable[TokenAlignments]) -> Iterable[TokenAlignments]:
     for alignment in alignments:
         yield TokenAlignments([correction] + alignment.corrections, distance + alignment.distance)

--- a/auchann/align_words.py
+++ b/auchann/align_words.py
@@ -147,7 +147,7 @@ class AlignmentSettings:
 
     def __init__(self):
         self.lookahead = 2
-        self.split_penalty = False
+        self.split_penalty = False  # if True, the script will favour an Alignment without a split replacement if distance is equal
         self.replacements = data.replacements
         self.fillers = data.fillers
         self.fragments = data.fragments

--- a/unit-tests/test_align.py
+++ b/unit-tests/test_align.py
@@ -6,7 +6,7 @@ def test_replace():
     correction_line = "doet zij even de armen weg"
     expected_chat_line = "doet zij even de armen wes [: weg]"
 
-    assertAlign(transcript_line, correction_line, expected_chat_line)
+    assert_align(transcript_line, correction_line, expected_chat_line)
 
 
 def test_remove():
@@ -14,15 +14,18 @@ def test_remove():
     correction_line = "alleen dit"
     expected_chat_line = "alleen dit [/] dit"
 
-    assertAlign(transcript_line, correction_line, expected_chat_line)
+    assert_align(transcript_line, correction_line, expected_chat_line)
 
 
 def test_insert():
-    transcript_line = "magge zien"
-    correction_line = "mag ik zien"
-    expected_chat_line = "magge [: mag] 0ik zien"
+    data = [
+        ("magge zien", "mag ik zien", "magge [: mag] 0ik zien"),
+        ("dit is huis", "dit is het huis", "dit is 0het huis"),
+        ("dit is huis ja", "dit is het huis ja", "dit is 0het huis ja")
+    ]
 
-    assertAlign(transcript_line, correction_line, expected_chat_line)
+    for transcript_line, correction_line, expected_chat_line in data:
+        assert_align(transcript_line, correction_line, expected_chat_line)
 
 
 def test_repetition():
@@ -30,7 +33,7 @@ def test_repetition():
     correction_line = "toen kwam hij bij een weiland"
     expected_chat_line = "toen kwam hij bij een [/] een weiland"
 
-    assertAlign(transcript_line, correction_line, expected_chat_line)
+    assert_align(transcript_line, correction_line, expected_chat_line)
 
 
 def test_error_detection():
@@ -38,7 +41,7 @@ def test_error_detection():
     correction_line = "het meisje sliep thuis"
     expected_chat_line = "de [: het] [* s:r:gc:art] meisje slaapte [: sliep] [* m] thuis"
 
-    assertAlign(transcript_line, correction_line, expected_chat_line)
+    assert_align(transcript_line, correction_line, expected_chat_line)
 
 
 def test_split():
@@ -67,10 +70,10 @@ def test_multi_word():
     ]
 
     for transcript_line, correction_line, expected_chat_line in data:
-        assertAlign(transcript_line, correction_line, expected_chat_line)
+        assert_align(transcript_line, correction_line, expected_chat_line)
 
 
-def assertAlign(transcript_line: str, correction_line: str, expected_chat_line: str):
+def assert_align(transcript_line: str, correction_line: str, expected_chat_line: str):
     settings = AlignmentSettings()
     def detect_error(original: str, correction: str):
         if original == "slaapte" and correction == "sliep":


### PR DESCRIPTION
This PR implements a solution to issue #19. It simply provides the user with the option to turn on 'split_penalty' in the settings, which will add a 0.1 penalty to the edit distance of Alignments that split tokens apart in a replacement. 

I have racked my brain and I think there is no issue with setting a penalty of 0.1 for operations that split a token, because it will only impact which Alignment is chosen in cases where the edit distance is equal. The unit tests all still pass, but I added it as a setting instead of hardcoding it in the source so that we might find a way to test it on a larger dataset, maybe with Jan's help/input. Please let me know what you think or if you see any issues with this approach.